### PR TITLE
Remove hardcoded username/password

### DIFF
--- a/apiclient/apiclient/cli.py
+++ b/apiclient/apiclient/cli.py
@@ -16,6 +16,7 @@ from apiclient.models import ConfigFile
 
 DEFAULT_CONFIG_FILE = os.path.join(xdg.BaseDirectory.save_config_path(
     'cath-swissmodel-api'), "config.json")
+LOG = logging.getLogger(__name__)
 
 
 class ApiConfig(object):
@@ -29,6 +30,7 @@ class ApiConfig(object):
         try:
             with open(filename) as infile:
                 self._config =  ConfigFile.load(infile)
+            LOG.debug("Loaded config from {}".format(filename))
         except Exception:
             self._config = ConfigFile()
 
@@ -39,6 +41,7 @@ class ApiConfig(object):
         setattr(self._config, key, value)
         with open(self.filename, "w") as outfile:
             self._config.save(outfile)
+        LOG.debug("Saved config to {}".format(self.filename))
 
 
 class ApiArgumentParser(argparse.ArgumentParser):

--- a/apiclient/apiclient/cli.py
+++ b/apiclient/apiclient/cli.py
@@ -9,6 +9,7 @@ import os
 
 DEFAULT_API_USER = 'junk@sillit.com'
 DEFAULT_API_PASSWORD = 'FJRbnz'
+DEFAULT_API_TOKEN = None
 
 class ApiArgumentParser(argparse.ArgumentParser):
     """
@@ -34,6 +35,9 @@ class ApiArgumentParser(argparse.ArgumentParser):
         self.add_argument('--pass',
                           type=str, required=False, dest='api_password', 
                           help='specify API password')
+        self.add_argument('--token',
+                          type=str, required=False, dest='api_token',
+                          help='specify API token')
         self.add_argument('--sleep',
                           type=int, default=5, 
                           help='waiting time between requests')
@@ -53,6 +57,9 @@ class ApiArgumentParser(argparse.ArgumentParser):
 
         if not args.api_password:
             args.api_password = self._get_env('API_PASSWORD', DEFAULT_API_PASSWORD)
+
+        if not args.api_token:
+            args.api_token = self._get_env('API_TOKEN', DEFAULT_API_TOKEN)
 
         return args
 

--- a/apiclient/apiclient/clients.py
+++ b/apiclient/apiclient/clients.py
@@ -144,6 +144,11 @@ class SubmitStatusResultsApiClient(ApiClientBase):
 
         return response_data
 
+    def set_token(self, *, api_token=None):
+        LOG.debug('Using token {}'.format(api_token))
+        headers = {'Authorization': 'token {}'.format(api_token)}
+        self.headers = headers
+
     def authenticate(self, *, api_user=None, api_pass=None):
         data = {'username': api_user, 'password': api_pass}
         LOG.debug('get_auth_headers.data: {}'.format(data))
@@ -158,6 +163,7 @@ class SubmitStatusResultsApiClient(ApiClientBase):
         response_data = r.json()
         if 'token' in response_data:
             token_id = response_data['token']
+            LOG.debug('Using token {}'.format(token_id))
         else:
             raise AuthenticationError("failed to get token from response: {}".format(r.text))
 
@@ -226,11 +232,13 @@ class SMAlignmentClient():
     Generates 3D model from alignment data (via SWISS-MODEL API)
     """
 
-    def __init__(self, *, infile, outfile, api_user, api_password, sleep=5, log_level=logging.INFO):
+    def __init__(self, *, infile, outfile, api_user=None, api_password=None,
+                 api_token=None, sleep=5, log_level=logging.INFO):
         self.infile = infile
         self.outfile = outfile
         self.api_user = api_user
         self.api_password = api_password
+        self.api_token = api_token
         self.sleep = sleep
         self.log_level = log_level
         self.apiclient = SMAlignmentApiClient()
@@ -239,7 +247,11 @@ class SMAlignmentClient():
     def new_from_cli(cls):
         parser = ApiArgumentParser(description=cls.__doc__)
         args = parser.parse_args()
-        required_args=('infile', 'outfile', 'api_user', 'api_password', 'sleep')
+        required_args = ('infile', 'outfile', 'sleep')
+        if 'api_token' in args and args.api_token is not None:
+            required_args += ('api_token', )
+        else:
+            required_args += ('api_user', 'api_password')
         kwargs = {k: v for k, v in vars(args).items() if k in required_args}
 
         level=logging.INFO
@@ -277,9 +289,12 @@ class SMAlignmentClient():
 
         LOG.info("DATA:  {}".format(self.infile))
         LOG.info("MODEL: {}".format(self.outfile))
-    
-        LOG.info("Authenticating ... ")
-        api.authenticate(api_user=self.api_user, api_pass=self.api_password)
+
+        if self.api_token is not None:
+            api.set_token(api_token=self.api_token)
+        else:
+            LOG.info("Authenticating ... ")
+            api.authenticate(api_user=self.api_user, api_pass=self.api_password)
 
         LOG.info("Loading data from file '%s' ...", self.infile)
         with open(self.infile) as infile:

--- a/apiclient/apiclient/clients.py
+++ b/apiclient/apiclient/clients.py
@@ -196,7 +196,7 @@ class SMAlignmentApiClient(SubmitStatusResultsApiClient):
                  auth_url=default_auth_url,
                  submit_url=default_submit_url,
                  status_url=default_status_url,
-                 results_url=default_results_url,
+                 results_url=default_results_url
                 ):
 
         # there has to be a nicer way of doing this?

--- a/apiclient/apiclient/models.py
+++ b/apiclient/apiclient/models.py
@@ -29,3 +29,26 @@ class SubmitAlignment(object):
         data = self.__dict__
         data = dict((k, v) for k, v in data.items() if v != None)
         return data
+
+
+class ConfigFile(object):
+    """ Represents the data in the configuration file """
+
+    def __init__(self, *, api_token=None):
+        self.api_token = api_token
+
+    @classmethod
+    def load(cls, infile):
+        """Creates a new instance of this model from a JSON filehandle."""
+        data = json.load(infile)
+        return cls(**data)
+
+    def as_dict(self):
+        """Represents the model as a dict (removes optional keys that do not have values)"""
+        data = self.__dict__
+        data = dict((k, v) for k, v in data.items() if v != None)
+        return data
+
+    def save(self, outfile):
+        """Saves this model to a JSON filehandle."""
+        json.dump(self.as_dict(), outfile)

--- a/apiclient/requirements-to-freeze.txt
+++ b/apiclient/requirements-to-freeze.txt
@@ -1,2 +1,3 @@
 requests
 colorlog
+pyxdg


### PR DESCRIPTION
Hi Ian,

I tested your new client and it's working great! 

The only thing that bugged me is the requirement to either hard-code the password or pass it in clear text on the command line. So... I made the client read it securely from the command line (with getpass), and then save the API token to a small json config file in the user home directory. Subsequent calls to the client will read the config and skip the /api-token-auth call altogether.

Hope you don't mind the extra requirement for the pyxdg library to locate a good default for the config file name.

Cheers,
Xavier