### PR TITLE
Allow more than one token to be stored in config

### DIFF
--- a/apiclient/README.md
+++ b/apiclient/README.md
@@ -1,7 +1,7 @@
 
 # API Clients
 
-This area contains scripts and libraries to simplify interaction with the CATH / SWISS-MODEL APIs.
+This area contains scripts and libraries to simplify interaction with APIs from [CATH](http://www.cathdb.info) (protein structure classification database) and [SWISS-MODEL](https://swissmodel.expasy.org/) (protein structure homology-modelling server).
 
 ### Layout
 
@@ -12,7 +12,7 @@ This area contains scripts and libraries to simplify interaction with the CATH /
 
 ### Examples
 
-**Build a 3D model with the SWISS-MODEL API**
+**Build a 3D model from template alignment data with the SWISS-MODEL API**
 
 ```bash
 $ ./scripts/api2.py --in example_data/A0PJE2__35-316.json --out tmp.pdb
@@ -23,16 +23,6 @@ input (ie `example_data/A0PJE2__35-316.json`):
 ```json
 {
     "auth_asym_id": "A",
-    "meta": {
-        "dope_score": -0.84426,
-        "funfam_id": "3.40.50.720-ff-290999",
-        "identity": 28.958000000000002,
-        "template.domain_id": "3rd5A00",
-        "template.pdb_start": "2",
-        "template.pdb_stop": "289",
-        "template.seqres_start": 1,
-        "template.seqres_stop": 291
-    },
     "pdb_id": "3rd5",
     "target_sequence": "---------E--VQIPGRVFLVTGGNSGI...",
     "template_seqres_offset": 0,

--- a/apiclient/apiclient/cli.py
+++ b/apiclient/apiclient/cli.py
@@ -4,6 +4,7 @@ Common classes and helpers for CLI interaction
 
 # core
 import argparse
+import json
 import logging
 import os
 
@@ -12,37 +13,9 @@ import xdg.BaseDirectory
 import getpass
 
 # local
-from apiclient.models import ConfigFile
+from apiclient.config import ApiConfig
 
-DEFAULT_CONFIG_FILE = os.path.join(xdg.BaseDirectory.save_config_path(
-    'cath-swissmodel-api'), "config.json")
 LOG = logging.getLogger(__name__)
-
-
-class ApiConfig(object):
-    """
-    Defines API configuration file (saves API token)
-    """
-
-    def __init__(self, filename=DEFAULT_CONFIG_FILE):
-        """Creates a new instance of config file from a JSON filehandle."""
-        self.filename = filename
-        try:
-            with open(filename) as infile:
-                self._config =  ConfigFile.load(infile)
-            LOG.debug("Loaded config from {}".format(filename))
-        except Exception:
-            self._config = ConfigFile()
-
-    def __getitem__(self, key):
-        return getattr(self._config, key)
-
-    def __setitem__(self, key, value):
-        setattr(self._config, key, value)
-        with open(self.filename, "w") as outfile:
-            self._config.save(outfile)
-        LOG.debug("Saved config to {}".format(self.filename))
-
 
 class ApiArgumentParser(argparse.ArgumentParser):
     """
@@ -62,12 +35,11 @@ class ApiArgumentParser(argparse.ArgumentParser):
         self.add_argument('--out',
                           type=str, required=True, dest='outfile', 
                           help='output results file')
-        self.add_argument('--config',
-                          type=str, dest='config',
-                          help='specify a config file storing the api_token '
-                               'in JSON format',
-                          default=DEFAULT_CONFIG_FILE)
-        self.add_argument('--user', 
+        self.add_argument('--delete-config',
+                          type=bool, dest='clear_config',
+                          help='remove settings from the config file',
+                          default=False)
+        self.add_argument('--user',
                           type=str, required=False, dest='api_user', 
                           help='specify API user')
         self.add_argument('--pass',
@@ -90,13 +62,9 @@ class ApiArgumentParser(argparse.ArgumentParser):
 
         args = super().parse_args()
 
-        args.config = ApiConfig(args.config)
-
         # Get API token. Order: arg, env, config
         if not args.api_token:
             args.api_token = self._get_env('API_TOKEN')
-        if not args.api_token:
-            args.api_token = args.config['api_token']
 
         if not args.api_token:
             # We need a username and password

--- a/apiclient/apiclient/clients.py
+++ b/apiclient/apiclient/clients.py
@@ -80,8 +80,9 @@ class SubmitStatusResultsApiClient(ApiClientBase):
         else:
             raise Exception("unexpected API method {}".format(method))
 
-        return r
+        self.process_response(r)
 
+        return r
 
     def submit(self, *, data=None, replacement_fields=None, status_success=201):
         """Submits the alignment data for modelling."""
@@ -171,16 +172,24 @@ class SubmitStatusResultsApiClient(ApiClientBase):
         self.headers = headers
         return token_id
 
+    def process_response(self, res):
+        """Hook to allow manipulation/inspection of all responses"""
+        pass
+
     def process_authenticate_response(self, res):
+        """Hook to allow manipulation/inspection of response to `authenticate` action"""
         pass
 
     def process_submit_response(self, res):
+        """Hook to allow manipulation/inspection of response to `submit` action"""
         pass
 
     def process_status_response(self, res):
+        """Hook to allow manipulation/inspection of response to `status` action"""
         pass
 
     def process_results_response(self, res):
+        """Hook to allow manipulation/inspection of response to `results` action"""
         pass
 
 
@@ -269,12 +278,6 @@ class SMAlignmentClient(object):
     def new_from_cli(cls):
         parser = ApiArgumentParser(description=cls.__doc__)
         args = parser.parse_args()
-        required_args = ('infile', 'outfile', 'sleep', 'config')
-        if 'api_token' in args and args.api_token is not None:
-            required_args += ('api_token', )
-        else:
-            required_args += ('api_user', 'api_password')
-        kwargs = {k: v for k, v in vars(args).items() if k in required_args}
 
         level=logging.INFO
         if args.verbose:
@@ -282,6 +285,10 @@ class SMAlignmentClient(object):
         if args.quiet:
             level=logging.WARNING
         cls.addLogger(level=level)
+
+        passthrough_args = ('infile', 'outfile', 'sleep', 'api_token', 'api_user', 'api_password')
+
+        kwargs = {k: v for k, v in vars(args).items() if k in passthrough_args}
 
         return cls(**kwargs)
 

--- a/apiclient/apiclient/config.py
+++ b/apiclient/apiclient/config.py
@@ -1,0 +1,68 @@
+# core
+import configparser
+import logging
+import os
+
+# non-core
+import xdg.BaseDirectory
+import getpass
+
+# local
+#from apiclient.models import ConfigFile
+from apiclient.error import ConfigError
+
+LOG = logging.getLogger(__name__)
+DEFAULT_CONFIG_FILE = os.path.join(xdg.BaseDirectory.save_config_path(
+    'cath-swissmodel-api'), "config.ini")
+
+class ApiConfig(object):
+    """
+    Defines API configuration file (saves API token)
+    """
+
+    def __init__(self, *, section='DEFAULT', filename=DEFAULT_CONFIG_FILE):
+        """Creates a new instance of config file from a JSON filehandle."""
+        self.filename = filename
+        self.section = str(section)
+
+        self._config = configparser.ConfigParser()
+
+        if os.path.isfile(filename):
+            self._config.read(filename)
+            LOG.debug("Loaded config from {}".format(filename))
+
+        if self.section not in self._config:
+            self._config[self.section] = {}
+
+    def delete_section(self, *, section_id=None):
+        """Removes all keys that match the given section."""
+        if not section_id:
+            section_id = self.section
+        del(self._config[section_id])
+        self.write()
+
+    def __contains__(self, key):
+        section = self._config[self.section]
+        return key in section
+
+    def __getitem__(self, key):
+        key = str(key)
+        section = self._config[self.section]
+        LOG.debug("__getitem__: {}, {} (type:{})".format(self.section, key, type(key)))
+        return section[key]
+
+    def __setitem__(self, key, value):
+        section = self._config[self.section]
+        section[key] = value
+        LOG.debug("Set config [{}] {}={}".format(self.section, key, value))
+        self.write()
+
+    def write(self):
+        with open(self.filename, 'w') as outfile:
+            self._config.write(outfile)
+        LOG.debug("Saved config to {}".format(self.filename))
+
+    def as_dict(self):
+        d = dict(self._config[self.section])
+        return d
+

--- a/apiclient/apiclient/error.py
+++ b/apiclient/apiclient/error.py
@@ -5,5 +5,11 @@ Defines errors that can occur within this library
 class ApiClientError(Exception):
     pass
 
+class ConfigError(Exception):
+    pass
+
+class ArgError(Exception):
+    pass
+
 class AuthenticationError(ApiClientError):
     pass

--- a/apiclient/apiclient/models.py
+++ b/apiclient/apiclient/models.py
@@ -1,4 +1,7 @@
 import json
+import logging
+
+LOG = logging.getLogger(__name__)
 
 class SubmitAlignment(object):
     """Represents the data required to submit a job to the SM Alignment API."""
@@ -30,25 +33,3 @@ class SubmitAlignment(object):
         data = dict((k, v) for k, v in data.items() if v != None)
         return data
 
-
-class ConfigFile(object):
-    """ Represents the data in the configuration file """
-
-    def __init__(self, *, api_token=None):
-        self.api_token = api_token
-
-    @classmethod
-    def load(cls, infile):
-        """Creates a new instance of this model from a JSON filehandle."""
-        data = json.load(infile)
-        return cls(**data)
-
-    def as_dict(self):
-        """Represents the model as a dict (removes optional keys that do not have values)"""
-        data = self.__dict__
-        data = dict((k, v) for k, v in data.items() if v != None)
-        return data
-
-    def save(self, outfile):
-        """Saves this model to a JSON filehandle."""
-        json.dump(self.as_dict(), outfile)

--- a/apiclient/tests/api2_test.py
+++ b/apiclient/tests/api2_test.py
@@ -1,6 +1,17 @@
+import json
+import os
+import configparser
+import tempfile
 import unittest
 
-from apiclient.clients import SMAlignmentApiClient
+from apiclient.config import ApiConfig
+from apiclient.clients import SMAlignmentApiClient, SMAlignmentClient
+
+DELETE_TEMP_FILES=False
+
+EXAMPLE_DATA_PATH = os.path.join(os.path.dirname(__file__), '..', 'example_data')
+EXAMPLE_USER='junk@sillit.com'
+EXAMPLE_PASSWORD='FJRbnz'
 
 class SMAlignmentApiClientTest(unittest.TestCase):
 
@@ -22,3 +33,85 @@ class SMAlignmentApiClientTest(unittest.TestCase):
         self.assertEqual(
             client.get_url('results', {"project_id": "foo"}),
             base_url + '/alignment/foo/')
+
+class ApiConfigTest(unittest.TestCase):
+
+    def test_defaults(self):
+
+        section1 = 'api1'
+        section2 = 'api2'
+
+        tmp_file = tempfile.NamedTemporaryFile(delete=DELETE_TEMP_FILES)
+        config_fname = tmp_file.name
+        tmp_file.close()
+
+        def parse_config():
+            conf = configparser.ConfigParser()
+            conf.read(config_fname)
+            d = {}
+            for s in conf.sections():
+                d[s] = dict(conf[s])
+            return d
+
+        config1 = ApiConfig(section=section1, filename=config_fname)
+        
+        self.assertIsNot(os.path.isfile(config_fname), 
+            'config file does not exist at start')
+
+        config1['foo'] = 'bar'
+        self.assertDictEqual(parse_config(), {"api1": {"foo": "bar"} }, 
+            'saved config data contains prefix')
+        self.assertEqual(config1['foo'], 'bar',
+            'prefix works as expected when retrieving data')
+
+        config2 = ApiConfig(section=section2, filename=config_fname)
+        config2['foo'] = 'barf'
+
+        self.assertDictEqual(dict(parse_config()), {"api1": {"foo": "bar"}, "api2": {"foo": "barf"}}, 
+            'same key different project looks okay')
+
+        self.assertEqual(config2['foo'], 'barf',
+            'prefix works as expected when retrieving data')
+
+        config2['foo'] = 'bingo'
+        config2['food'] = 'apple'
+
+        self.assertDictEqual(parse_config(), {"api1": {"foo": "bar"}, "api2": {"foo": "bingo", "food": "apple"}},
+            'add/updated data looks okay')
+
+        config2.delete_section(section_id=section2)
+        self.assertDictEqual(parse_config(), {"api1": {"foo": "bar"}}, 
+            'delete_section() works okay')
+
+
+class SMAlignmentClientTest(unittest.TestCase):
+
+    def test_defaults(self):
+
+        infile = os.path.join(EXAMPLE_DATA_PATH, 'A0PJE2__35-316.json')
+
+        def atom_lines(pdbfile):
+            atom_lines = None
+            with open(pdbfile) as f:
+                atom_lines = [f for line in f if line.startswith('ATOM')]
+            return atom_lines
+
+        # run with user auth
+        outfile1 = tempfile.NamedTemporaryFile(delete=DELETE_TEMP_FILES)
+        client1 = SMAlignmentClient(infile=infile, outfile=outfile1.name, 
+            api_user=EXAMPLE_USER, api_password=EXAMPLE_PASSWORD)
+        client1.run()
+
+        api_token = client1.api_token
+
+        self.assertTrue(os.path.isfile(outfile1.name), 'outfile exists (user auth)')
+        self.assertEqual(len(atom_lines(outfile1.name)), 2187, 'correct number of atoms')
+
+        # run with token auth
+        outfile2 = tempfile.NamedTemporaryFile(delete=DELETE_TEMP_FILES)
+        client2 = SMAlignmentClient(infile=infile, outfile=outfile2.name, 
+            api_token=api_token)
+        client2.run()
+        self.assertTrue(os.path.isfile(outfile2.name), 'outfile exists (token auth)')
+        self.assertEqual(len(atom_lines(outfile2.name)), 2187, 'correct number of atoms')
+


### PR DESCRIPTION
We are going to have multiple clients (api1, api2, etc) so we need to be able to store separate config for each client.

* merge API code into single, separate module `config.py` (from `cli.py` and `models.py`)
* uses core module `configparser` to separate config for multiple clients 
* move validation of authentication arguments upstream to `__init__` (rather than when cli args are processed)
* add `--delete-config` option
* add tests:
  * check that config works as expected
  * runs full API with user / token auth 

@xrobin - I think these changes are okay, but could you check you're okay with them?
